### PR TITLE
fix msw appointment format in base-lazydays

### DIFF
--- a/base-lazy-days/client/src/mocks/handlers.js
+++ b/base-lazy-days/client/src/mocks/handlers.js
@@ -15,9 +15,9 @@ export const handlers = [
   //   return res(ctx.json(mockStaff));
   // }),
   // rest.get(
-  //   'http://localhost:3030/appointments/:month/:year',
+  //   'http://localhost:3030/appointments/:year/:month',
   //   (req, res, ctx) => {
-  //     return res(ctx.json({ appointments: mockAppointments }));
+  //     return res(ctx.json(mockAppointments));
   //   },
   // ),
   // rest.get('http://localhost:3030/user/:id/appointments', (req, res, ctx) => {


### PR DESCRIPTION
Hi,
I spent some time debugging the appointments tests before noticing that although corrected in the completed version of the app, the mock data for appointments was still using incorrect format in the commented version included in the base-app. Thought it might make sense to fix it here too, in order to save future learners the same trouble.

Cheers,
Juho